### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 CC ?= clang
 CXX ?= clang++
-override CXXFLAGS += -Wall -Wextra -Werror -std=c++11
+override CXXFLAGS += -Wall -fPIC -Wextra -Werror -std=c++11
 override CFLAGS += -Wall -Wextra -pedantic
 AR ?= ar
 


### PR DESCRIPTION
fixed compile error "**_relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC_**" when references in [heartlocker/JavaCallCSharp](https:://github.com/heartlocker/JavaCallCSharp "JavaCallCSharp")